### PR TITLE
fix auth-dependent data caching by adding `useSWRMutationWithAuthKey` and `mutateWithAuthKey`

### DIFF
--- a/app/interview/[application_id]/page.tsx
+++ b/app/interview/[application_id]/page.tsx
@@ -44,7 +44,7 @@ export default function InterviewExperiencePage() {
   } = useSWR<InterviewExperienceCardData[]>(API.INTERVIEW.getAllByApplicationId(application_id as string), fetcher);
 
   // Update application and interview rounds
-  const { updateApplicationAndInterviewRounds, isUpdating } = useUpdateApplicationAndInterviewRounds(application_id as string);
+  const { updateApplicationAndInterviewRounds, isUpdating } = useUpdateApplicationAndInterviewRounds(application_id as string, userId);
 
   // local states
   const [isEditing, setIsEditing] = useState(false);

--- a/app/job/[job_posting_id]/page.tsx
+++ b/app/job/[job_posting_id]/page.tsx
@@ -86,7 +86,7 @@ export default function JobDetailsPage() {
 
   // console.warn("applications", applications);
 
-  const { createApplication, isCreating } = useCreateApplication(job_posting_id as string);
+  const { createApplication, isCreating } = useCreateApplication(job_posting_id as string, userId);
 
   if (isLoading || applicationsIsLoading) return <LoadingContent />;
   if (error || applicationsError) {

--- a/app/question/[comment_id]/CommentSection.tsx
+++ b/app/question/[comment_id]/CommentSection.tsx
@@ -40,18 +40,24 @@ export function CommentSection({ entity_type, entity_id }: CommentSectionProps) 
 
   // console.error("comments", comments);
 
-  const { createComment, isCreating } = useCreateComment({
-    entity_type,
-    entity_id,
-  });
+  const { createComment, isCreating } = useCreateComment(
+    {
+      entity_type,
+      entity_id,
+    },
+    userId,
+  );
 
   const [editingComment, setEditingComment] = useState<EditingComment>(null);
 
-  const { updateComment, isUpdating } = useUpdateComment({
-    entity_type,
-    comment_id: editingComment?.id || "",
-    entity_id,
-  });
+  const { updateComment, isUpdating } = useUpdateComment(
+    {
+      entity_type,
+      comment_id: editingComment?.id || "",
+      entity_id,
+    },
+    userId,
+  );
 
   const handleSubmitEditComment = async (content: string) => {
     try {

--- a/app/question/[comment_id]/page.tsx
+++ b/app/question/[comment_id]/page.tsx
@@ -34,10 +34,13 @@ export default function QuestionPage() {
 
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
 
-  const { updateComment, isUpdating } = useUpdateComment({
-    entity_type: "job_posting",
-    comment_id: editingCommentId || "",
-  });
+  const { updateComment, isUpdating } = useUpdateComment(
+    {
+      entity_type: "job_posting",
+      comment_id: editingCommentId || "",
+    },
+    userId,
+  );
 
   if (isLoading) return <LoadingContent />;
   if (error) {

--- a/lib/hooks/useCreateApplication.ts
+++ b/lib/hooks/useCreateApplication.ts
@@ -1,15 +1,15 @@
-import useSWRMutation from "swr/mutation";
+import { ClerkAuthUserId, useSWRMutationWithAuthKey } from "./useSWRWithAuthKey";
 
 import actionCreateApplication, { CreateApplicationArgs } from "@/app/actions/createApplication";
 import { API } from "@/lib/constants/apiRoutes";
 
 type CreateApplicationParams = StrictOmit<CreateApplicationArgs, "job_posting_id">;
 
-export const useCreateApplication = (job_posting_id: string) => {
-  const { trigger, isMutating } = useSWRMutation(API.APPLICATION.getAllByJobPostingId(job_posting_id), actionCreateApplication);
+export const useCreateApplication = (job_posting_id: string, userId: ClerkAuthUserId) => {
+  const { trigger, isMutating } = useSWRMutationWithAuthKey(API.APPLICATION.getAllByJobPostingId(job_posting_id), userId, actionCreateApplication);
 
   return {
-    createApplication: async (params: CreateApplicationParams) => {
+    createApplication: async (params: CreateApplicationParams): Promise<void> => {
       const result = await trigger({ job_posting_id, ...params });
 
       if (!result.isSuccess) {

--- a/lib/hooks/useCreateComment.ts
+++ b/lib/hooks/useCreateComment.ts
@@ -1,14 +1,15 @@
-import useSWRMutation from "swr/mutation";
-
 import actionCreateComment from "@/app/actions/createComment";
 import { API } from "@/lib/constants/apiRoutes";
+import { ClerkAuthUserId, useSWRMutationWithAuthKey } from "@/lib/hooks/useSWRWithAuthKey";
 
 export type ServerCreateCommentArgs = Pick<CommentTable, "entity_type" | "entity_id" | "content">;
 
 type ClientCreateCommentArgs = StrictOmit<ServerCreateCommentArgs, "content">;
 
-export const useCreateComment = ({ entity_type, entity_id }: ClientCreateCommentArgs) => {
-  const { trigger, isMutating } = useSWRMutation(API.COMMENT.getAllByThisEntity(entity_id, entity_type), actionCreateComment);
+export const useCreateComment = (args: ClientCreateCommentArgs, userId: ClerkAuthUserId) => {
+  const { entity_type, entity_id } = args;
+
+  const { trigger, isMutating } = useSWRMutationWithAuthKey(API.COMMENT.getAllByThisEntity(entity_id, entity_type), userId, actionCreateComment);
 
   return {
     createComment: async (content: string) => {

--- a/lib/hooks/useCreateCompany.ts
+++ b/lib/hooks/useCreateCompany.ts
@@ -12,12 +12,10 @@ const useCreateCompany = () => {
     createCompany: async (newCompany: CompanyFormData) => {
       const result = await trigger(newCompany);
 
-      if (!result.success) {
+      if (!result.isSuccess) {
         // Create an error object with the returned error message
         throw new Error(result.error);
       }
-
-      return true;
     },
     isCreating: isMutating,
   };

--- a/lib/hooks/useCreateJob.ts
+++ b/lib/hooks/useCreateJob.ts
@@ -11,7 +11,7 @@ const useCreateJob = (company_id: string) => {
     createJob: async (newJob: AddJobFormData, company_name: string) => {
       const result = await trigger({ company_id, newJob, company_name });
 
-      if (!result.success) {
+      if (!result.isSuccess) {
         // Create an error object with the returned error message
         throw new Error(result.error);
       }

--- a/lib/hooks/useSWRWithAuthKey.ts
+++ b/lib/hooks/useSWRWithAuthKey.ts
@@ -1,4 +1,5 @@
-import useSWR, { SWRConfiguration } from "swr";
+import useSWR, { mutate, SWRConfiguration } from "swr";
+import useSWRMutation, { SWRMutationConfiguration } from "swr/mutation";
 
 import { fetcher } from "@/lib/fetcher";
 
@@ -7,6 +8,7 @@ export const ANON_USER_ID = "anonymous"; // Sentinel value for anonymous users -
 export type ClerkAuthUserId = string | null | undefined;
 
 type AuthDependentKey = readonly [RequestInfo, ClerkAuthUserId];
+type AuthDependentMutationKey = readonly [string, string];
 
 /**
  * Fetcher function that extracts the URL from the cache key tuple
@@ -20,7 +22,7 @@ export const authDependentFetcher = async <T = any>([url, _userId]: AuthDependen
  * SWR hook that includes auth state in the cache key
  *
  * @param url - The API endpoint to fetch data from
- * @param userId - The current user's ID (or ANON_USER_ID if not authenticated)
+ * @param userId - The current user's ID (will use ANON_USER_ID if not authenticated)
  * @param options - Standard SWR configuration options
  * @returns SWR response with data, error, and other SWR properties
  *
@@ -29,11 +31,49 @@ export const authDependentFetcher = async <T = any>([url, _userId]: AuthDependen
  * const { userId } = useAuth();
  * const { data, error } = useSWRWithAuthKey('/api/user-data', userId);
  */
-export const useSWRWithAuthKey = <T>(url: RequestInfo, userId: ClerkAuthUserId, options?: SWRConfiguration<T>) => {
+export const useSWRWithAuthKey = <T>(url: RequestInfo | null | undefined, userId: ClerkAuthUserId, options?: SWRConfiguration<T>) => {
   // Create a stable cache key that changes when auth state changes.
   // Use the sentinel value for anonymous users to ensure consistency.
   // If userId is undefined, it means the user is anonymous.
   const swrKey: AuthDependentKey | null = url ? ([url, userId ?? ANON_USER_ID] as const) : null;
 
   return useSWR<T>(swrKey, authDependentFetcher, options);
+};
+
+/**
+ * SWR mutation hook that includes auth state in the cache key
+ *
+ * @param url - The API endpoint for the mutation
+ * @param userId - The current user's ID (will use ANON_USER_ID if not authenticated)
+ * @param mutationFn - The mutation function to execute
+ * @param options - Standard SWR mutation configuration options
+ * @returns SWR mutation response with trigger, isMutating, and other SWR mutation properties
+ *
+ * @example
+ * // In a component:
+ * const { userId } = useAuth();
+ * const { trigger, isMutating } = useSWRMutationWithAuthKey(
+ *   '/api/create-item',
+ *   userId,
+ *   createItemAction
+ * );
+ */
+export const useSWRMutationWithAuthKey = <TArg, TResult, TError = Error>(
+  url: string | null | undefined,
+  userId: ClerkAuthUserId,
+  mutationFn: (url: string, opts: { arg: TArg }) => Promise<TResult>,
+  options?: SWRMutationConfiguration<TResult, TError, AuthDependentMutationKey, TArg>,
+) => {
+  const swrKey: AuthDependentMutationKey | null = url ? ([url, userId ?? ANON_USER_ID] as const) : null;
+
+  return useSWRMutation(swrKey, async ([url]: AuthDependentMutationKey, opts: { arg: TArg }) => mutationFn(url, opts), options);
+};
+
+/**
+ * Mutate function that uses the same cache key format as `useSWRWithAuthKey`
+ * @param url - The API endpoint to invalidate
+ * @param userId - The current user's ID (will use ANON_USER_ID if not authenticated)
+ */
+export const mutateWithAuthKey = (url: string, userId: ClerkAuthUserId) => {
+  return mutate([url, userId ?? ANON_USER_ID]);
 };

--- a/lib/hooks/useUpdateApplicationAndInterviewRounds.ts
+++ b/lib/hooks/useUpdateApplicationAndInterviewRounds.ts
@@ -1,12 +1,10 @@
-import useSWRMutation from "swr/mutation";
-import { mutate } from "swr";
-
 import { API } from "@/lib/constants/apiRoutes";
 import { InterviewExperienceFormValues } from "@/lib/schema/updateInterviewRoundSchema";
 import actionUpdateApplicationAndInterviewRounds from "@/app/actions/updateApplicationAndInterviewRounds";
+import { ClerkAuthUserId, mutateWithAuthKey, useSWRMutationWithAuthKey } from "@/lib/hooks/useSWRWithAuthKey";
 
-export const useUpdateApplicationAndInterviewRounds = (application_id: string) => {
-  const { trigger, isMutating } = useSWRMutation(API.INTERVIEW.getAllByApplicationId(application_id), actionUpdateApplicationAndInterviewRounds);
+export const useUpdateApplicationAndInterviewRounds = (application_id: string, userId: ClerkAuthUserId) => {
+  const { trigger, isMutating } = useSWRMutationWithAuthKey(API.INTERVIEW.getAllByApplicationId(application_id), userId, actionUpdateApplicationAndInterviewRounds);
 
   return {
     updateApplicationAndInterviewRounds: async (data: InterviewExperienceFormValues) => {
@@ -16,7 +14,7 @@ export const useUpdateApplicationAndInterviewRounds = (application_id: string) =
           application_id,
         });
 
-        mutate(API.APPLICATION.getByApplicationId(application_id));
+        mutateWithAuthKey(API.APPLICATION.getByApplicationId(application_id), userId);
       } catch (err) {
         console.error("Error updating application and interview rounds:", err);
         throw err;

--- a/lib/hooks/useUpdateComment.ts
+++ b/lib/hooks/useUpdateComment.ts
@@ -1,15 +1,15 @@
-import useSWRMutation from "swr/mutation";
-
 import { API } from "@/lib/constants/apiRoutes";
 import actionUpdateComment from "@/app/actions/updateComment";
+import { ClerkAuthUserId, useSWRMutationWithAuthKey } from "@/lib/hooks/useSWRWithAuthKey";
 
 type UpdateCommentArgs = { entity_type: "job_posting"; comment_id: string; entity_id?: never } | { entity_type: "question" | "interview_experience"; comment_id: string; entity_id: string };
 
-export const useUpdateComment = (args: UpdateCommentArgs) => {
+export const useUpdateComment = (args: UpdateCommentArgs, userId: ClerkAuthUserId) => {
   const { entity_type, comment_id, entity_id } = args;
 
-  const { trigger, isMutating } = useSWRMutation(
+  const { trigger, isMutating } = useSWRMutationWithAuthKey(
     entity_type === "job_posting" ? API.COMMENT.getById(comment_id) : API.COMMENT.getAllByThisEntity(entity_id, entity_type), // job_posting = question page's main question
+    userId,
     actionUpdateComment,
   );
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^5.5.2",
-    "@clerk/themes": "^2.1.42",
+    "@clerk/themes": "2.3.3",
     "@heroui/react": "2.7.2",
     "@hookform/resolvers": "^3.9.0",
     "@internationalized/date": "3.7.0",


### PR DESCRIPTION
fix #4 

- add `useSWRMutationWithAuthKey` and `mutateWithAuthKey` due to changes using `useSWRWithAuthKey`
- Updated `@clerk/themes` dependency to version 2.3.3.
- Refactored `actionCreateCompany` and `actionCreateJob` to use `ServerActionResult` for consistent return types.
- Updated hooks (`useCreateApplication`, `useCreateJob`, `useCreateComment`, `useUpdateComment`, `useUpdateApplicationAndInterviewRounds`) to accept `userId`.
- Replaced `success` with `isSuccess` in various return statements for consistency across server actions.