### PR TITLE
fix: exclude rejected jobs from company details page

### DIFF
--- a/app/api/company/[company_id]/job/route.ts
+++ b/app/api/company/[company_id]/job/route.ts
@@ -5,6 +5,7 @@ import { DBTable } from "@/lib/constants/dbTables";
 import { buildSelectString } from "@/lib/buildSelectString";
 import { SelectObject } from "@/lib/buildSelectString";
 import { ERROR_CODES, ERROR_MESSAGES } from "@/lib/errorHandling";
+import { JOB_STATUS } from "@/lib/constants/jobPostingStatus";
 
 // Select all the jobs from job_posting table for a company on the specific company page
 
@@ -35,7 +36,7 @@ export async function GET(request: Request, { params }: { params: { company_id: 
     .from(DBTable.JOB_POSTING)
     .select(selectString)
     .eq("company_id", params.company_id)
-    .neq("job_status", "Rejected")
+    .neq("job_status", JOB_STATUS.Rejected)
     .order("job_posted_date", { ascending: true })
     .order("updated_at", { ascending: false });
 


### PR DESCRIPTION
## Summary
Fixes #20

Jobs with 'Rejected' status were incorrectly appearing on the company details page (\/company/{company_id}\).

## Changes
Added a filter to the Supabase query in \pp/api/company/[company_id]/job/route.ts\ to exclude jobs where \job_status = 'Rejected'\.

## Testing
1. Create a job under a company
2. Update the job status to 'Rejected' in the database
3. Verify that the rejected job no longer appears on the \/company/{company_id}\ page