### PR TITLE
fix: use correct grammar for closing date badges

### DIFF
--- a/app/jobs/AllJobSearchResult.tsx
+++ b/app/jobs/AllJobSearchResult.tsx
@@ -12,7 +12,7 @@ import { fetcher } from "@/lib/fetcher";
 import { API } from "@/lib/constants/apiRoutes";
 import { useDebounce } from "@/lib/hooks/useDebounce";
 import { DBTable } from "@/lib/constants/dbTables";
-import { formatHowLongAgo, isRecentDate } from "@/lib/formatDateUtils";
+import { formatHowLongAgo, isRecentDate, formatClosingDate } from "@/lib/formatDateUtils";
 import { ImageWithFallback } from "@/components/ImageWithFallback";
 import { isRateLimitError } from "@/lib/errorHandling";
 import { RateLimitErrorMessage } from "@/components/RateLimitErrorMessage";
@@ -150,7 +150,7 @@ export function AllJobSearchResult() {
                           )}
                           {job.closed_date && (
                             <CustomChip color="warning" size="sm" variant="flat">
-                              Closing {formatHowLongAgo(job.closed_date)}
+                              {formatClosingDate(job.closed_date)}
                             </CustomChip>
                           )}
                         </div>

--- a/lib/formatDateUtils.ts
+++ b/lib/formatDateUtils.ts
@@ -54,3 +54,25 @@ export function formatHowLongAgo(date: Date | string | number) {
 export function getDaysBetween(earlierDate: Date | string | number, laterDate: Date | string | number) {
   return differenceInDays(new Date(laterDate), new Date(earlierDate));
 }
+
+export function formatClosingDate(date: Date | string | number): string {
+  const now = new Date();
+  const closeDate = new Date(date);
+
+  if (closeDate < now) {
+    return `Closed ${formatDistanceToNowStrict(closeDate, { addSuffix: true })}`;
+  }
+
+  // Check if it's today
+  if (typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    const todayDate = today(getLocalTimeZone());
+    const [year, month, day] = date.split("-").map(Number);
+    const compareDate = new CalendarDate(year, month, day);
+
+    if (compareDate.compare(todayDate) === 0) {
+      return "Closes today";
+    }
+  }
+
+  return `Closes ${formatDistanceToNowStrict(closeDate, { addSuffix: true })}`;
+}


### PR DESCRIPTION
Fixes #32

## Problem

The closing date badge showed "Closing 5 days ago" which is grammatically incorrect.

## Solution

Added `formatClosingDate()` helper that returns:
- "Closed X ago" for past dates
- "Closes today" for today
- "Closes in X" for future dates

## Changes

- `lib/formatDateUtils.ts`: Added `formatClosingDate` function
- `app/jobs/AllJobSearchResult.tsx`: Use the new function for the closing badge