### PR TITLE
feat: add View button to company creation toast

### DIFF
--- a/app/actions/createCompany.ts
+++ b/app/actions/createCompany.ts
@@ -11,9 +11,11 @@ import { extractDomain } from "@/lib/extractDomain";
 import { mpServerTrack } from "@/lib/mixpanelServer";
 import { ServerActionResult } from "@/lib/sharedTypes";
 
+export type CreateCompanyResult = { company_id: string };
+
 // TODO Aug: use safeParse instead of parse. refactor rate limit, remove try catch outer
 
-const actionCreateCompany = async (key: string, { arg: newCompany }: { arg: CompanyFormData }): Promise<ServerActionResult> => {
+const actionCreateCompany = async (key: string, { arg: newCompany }: { arg: CompanyFormData }): Promise<ServerActionResult<CreateCompanyResult>> => {
   try {
     return await withRateLimit(async (user_id) => {
       const supabase = await createClerkSupabaseClientSsr();
@@ -28,7 +30,7 @@ const actionCreateCompany = async (key: string, { arg: newCompany }: { arg: Comp
           user_id,
         };
 
-        const { error } = await supabase.from(DBTable.COMPANY).insert(dataToInsert).select();
+        const { data, error } = await supabase.from(DBTable.COMPANY).insert(dataToInsert).select("id").single();
 
         if (error) {
           console.error("Create Company error duplicate:", error);
@@ -58,7 +60,7 @@ const actionCreateCompany = async (key: string, { arg: newCompany }: { arg: Comp
           user_id,
         });
 
-        return { isSuccess: true };
+        return { isSuccess: true, data: { company_id: data.id } };
       } catch (err) {
         // Add general error tracking for non-duplicate errors
         console.error("Create Company error:", err);

--- a/app/companies/CreateCompanyModal.tsx
+++ b/app/companies/CreateCompanyModal.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 import { useCreateCompany } from "@/lib/hooks/useCreateCompany";
 import { ERROR_MESSAGES, getErrorMessage, isRateLimitError } from "@/lib/errorHandling";
@@ -16,6 +17,7 @@ type CreateCompanyModalProps = {
 };
 
 export function CreateCompanyModal({ isOpen, onClose, onSubmitSuccess }: CreateCompanyModalProps) {
+  const router = useRouter();
   const { createCompany, isCreating } = useCreateCompany();
 
   const {
@@ -36,9 +38,14 @@ export function CreateCompanyModal({ isOpen, onClose, onSubmitSuccess }: CreateC
 
   const onSubmit = async (data: CompanyFormData) => {
     try {
-      await createCompany(data);
+      const { company_id } = await createCompany(data);
 
-      toast.success("Company created successfully");
+      toast.success("Company created successfully", {
+        action: {
+          label: "View",
+          onClick: () => router.push(`/company/${company_id}`),
+        },
+      });
 
       reset();
       onSubmitSuccess();

--- a/lib/hooks/useCreateCompany.ts
+++ b/lib/hooks/useCreateCompany.ts
@@ -13,9 +13,10 @@ const useCreateCompany = () => {
       const result = await trigger(newCompany);
 
       if (!result.isSuccess) {
-        // Create an error object with the returned error message
         throw new Error(result.error);
       }
+
+      return result.data;
     },
     isCreating: isMutating,
   };


### PR DESCRIPTION
Fixes #8

## Changes

- Modified `createCompany` action to return the created company's ID
- Updated `useCreateCompany` hook to expose the company ID
- Added "View" action button to the success toast that navigates to `/company/{id}`

## Screenshots

The toast now includes a "View" button that takes users directly to the newly created company page.