### PR TITLE
feat: animate star count with NumberTicker

### DIFF
--- a/components/NumberTicker.tsx
+++ b/components/NumberTicker.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ComponentPropsWithoutRef, useEffect, useRef } from "react";
+import { useInView, useMotionValue, useSpring } from "framer-motion";
+import { cn } from "@heroui/react";
+
+interface NumberTickerProps extends ComponentPropsWithoutRef<"span"> {
+  value: number;
+  startValue?: number;
+  direction?: "up" | "down";
+  delay?: number;
+  decimalPlaces?: number;
+}
+
+export function NumberTicker({ value, startValue = 0, direction = "up", delay = 0, className, decimalPlaces = 0, ...props }: NumberTickerProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const motionValue = useMotionValue(direction === "down" ? value : startValue);
+  const springValue = useSpring(motionValue, {
+    damping: 60,
+    stiffness: 100,
+  });
+  const isInView = useInView(ref, { once: true, margin: "0px" });
+
+  useEffect(() => {
+    if (isInView) {
+      const timer = setTimeout(() => {
+        motionValue.set(direction === "down" ? startValue : value);
+      }, delay * 1000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [motionValue, isInView, delay, value, direction, startValue]);
+
+  useEffect(
+    () =>
+      springValue.on("change", (latest) => {
+        if (ref.current) {
+          ref.current.textContent = Intl.NumberFormat("en-US", {
+            minimumFractionDigits: decimalPlaces,
+            maximumFractionDigits: decimalPlaces,
+          }).format(Number(latest.toFixed(decimalPlaces)));
+        }
+      }),
+    [springValue, decimalPlaces],
+  );
+
+  return (
+    <span ref={ref} className={cn("inline-block tabular-nums", className)} {...props}>
+      {startValue}
+    </span>
+  );
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -10,6 +10,7 @@ import mixpanel from "mixpanel-browser";
 
 import { ClerkUserButton } from "./ClerkUserButton";
 import { GithubIcon } from "./icons";
+import { NumberTicker } from "./NumberTicker";
 
 import { siteConfig } from "@/config/site";
 import { CustomButton } from "@/components/CustomButton";
@@ -158,7 +159,7 @@ export const Navbar = () => {
             onPress={handleGithubClick}
           >
             <GithubIcon />
-            <span className="hidden md:inline"> Star {githubLoading ? "" : githubStars}</span>
+            <span className="hidden md:inline"> Star {!githubLoading && githubStars > 0 && <NumberTicker value={githubStars} />}</span>
           </Link>
         </NavbarItem>
 


### PR DESCRIPTION
Fixes #22

## Changes

- Added `NumberTicker` component from Magic UI (adapted for framer-motion)
- Updated navbar to use NumberTicker for the GitHub star count
- Star count now animates from 0 to actual value on page load

## Implementation

The component uses framer-motion's `useSpring` for smooth animation and `useInView` to trigger when visible.

## References

- Based on [Magic UI NumberTicker](https://magicui.design/docs/components/number-ticker)
- Similar pattern to existing `ShimmerButton` component