### PR TITLE
fix: show 'Closing tomorrow' for date-only closed_date

### DIFF
--- a/lib/formatDateUtils.ts
+++ b/lib/formatDateUtils.ts
@@ -44,6 +44,12 @@ export function formatHowLongAgo(date: Date | string | number) {
     if (compareDate.compare(todayDate) === 0) {
       return "today";
     }
+
+    const tomorrowDate = todayDate.add({ days: 1 });
+
+    if (compareDate.compare(tomorrowDate) === 0) {
+      return "tomorrow";
+    }
   }
 
   return formatDistanceToNowStrict(new Date(date), {


### PR DESCRIPTION
## Summary

- Date-only `closed_date` values (`YYYY-MM-DD`) are parsed as midnight UTC by `new Date()`, so `formatDistanceToNowStrict` was showing misleading "Closing in X hours" for dates that are tomorrow in the user's local timezone
- Added a calendar-date-based tomorrow check in `formatHowLongAgo` using `@internationalized/date`, consistent with the existing "today" check
- The chip now correctly shows **"Closing tomorrow"** instead of "Closing in 17 hours"

## Changes

**`lib/formatDateUtils.ts`** — After the existing "today" equality check, compute tomorrow's `CalendarDate` via `todayDate.add({ days: 1 })` and return `"tomorrow"` when the closing date matches.

## Test plan

- [x] Set a job's `closed_date` to tomorrow's date (YYYY-MM-DD) → chip should show "Closing tomorrow"
- [x] Set a job's `closed_date` to today's date → chip should still show "Closing today"
- [x] Set a job's `closed_date` to 3 days from now → chip should show "Closing in 3 days"
- [x] Verify in different timezones (e.g. UTC-8, UTC+5) that tomorrow is computed based on local time

Fixes #37